### PR TITLE
TypeScript definitions

### DIFF
--- a/nullthrows-tests.ts
+++ b/nullthrows-tests.ts
@@ -1,0 +1,18 @@
+// This code does not run, but it is type-checked.
+
+import nullthrows from ".";
+
+["string array"].push(nullthrows(maybeString()));
+
+function maybeString() {
+  switch (Math.floor(Math.random() * 3)) {
+    case 0:
+      return null;
+
+    case 1:
+      return undefined;
+
+    default:
+      return "string indeed";
+  }
+}

--- a/nullthrows.d.ts
+++ b/nullthrows.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Throws if value is null or undefined, otherwise returns value.
+ */
+export default function nullthrows<T>(value?: T | null): T;

--- a/package.json
+++ b/package.json
@@ -6,22 +6,31 @@
     "assert",
     "flow",
     "invariant",
-    "nullthrows"
+    "nullthrows",
+    "typescript"
   ],
   "license": "MIT",
   "author": "Andres Suarez <zertosh@gmail.com>",
+  "contributors": [
+    "makepost <makepost@firemail.cc>"
+  ],
   "files": [
+    "nullthrows.d.ts",
     "nullthrows.js",
     "nullthrows.js.flow"
   ],
-  "main": "nullthrows.js",
+  "main": "nullthrows",
+  "types": "nullthrows",
   "repository": "https://github.com/zertosh/nullthrows",
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "tap test/*.js && tsc && tslint -p ."
   },
   "dependencies": {},
   "devDependencies": {
+    "dtslint": "^0.2.0",
     "flow-bin": "0.30.0",
-    "tap": "^6.2.0"
+    "tap": "^6.2.0",
+    "tslint": "^5.8.0",
+    "typescript": "^2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "nullthrows",
   "repository": "https://github.com/zertosh/nullthrows",
   "scripts": {
-    "test": "tap test/*.js && tsc && tslint -p ."
+    "test": "tap test/*.js && tsc"
   },
   "dependencies": {},
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "baseUrl": "./",
+    "typeRoots": [
+      "./"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "nullthrows-tests.ts",
+    "nullthrows.d.ts"
+  ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "tslint:latest",
+    "dtslint/dt.json"
+  ]
+}


### PR DESCRIPTION
Nullthrows can improve readability of JavaScript and TypeScript apps with strict null checks.

```typescript
// Type 'PlaceService | null' has no property 'shortNames' and no string index signature.
const { shortNames, status } = this.props.placeService;

// Line wrap in JavaScript.
const { shortNames, status } = /** @type {PlaceService} */ (this.props.placeService);

// Unwanted repetition in TypeScript.
const { shortNames, status } = this.props.placeService as PlaceService;

// Ok.
const { shortNames, status } = Nullthrows(this.props.placeService);
```