### PR TITLE
Add a second argument for a custom error message

### DIFF
--- a/__tests__/__fixtures__/flow-package/index.js
+++ b/__tests__/__fixtures__/flow-package/index.js
@@ -6,5 +6,6 @@ var obj = ({}: ?Object);
 
 var ok1 = nullthrows(obj);
 var ok2 = nullthrows(null);
+var ok3 = nullthrows(null, 'my error message');
 
 var bad1: Object = obj;

--- a/__tests__/__fixtures__/typescript-package/index.ts
+++ b/__tests__/__fixtures__/typescript-package/index.ts
@@ -4,7 +4,8 @@ function fn(): string | null {
   return Math.random() < 0.5 ? 'hello' : null;
 }
 
-var good: string = nullthrows(fn());
+var good1: string = nullthrows(fn());
+var good2: string = nullthrows(fn(), 'my error message');
 
 var bad1: string = fn();
 

--- a/__tests__/__snapshots__/typechecker-test.js.snap
+++ b/__tests__/__snapshots__/typechecker-test.js.snap
@@ -3,16 +3,16 @@
 exports[`nullthrows with flow 1`] = `""`;
 
 exports[`nullthrows with flow 2`] = `
-"__tests__/__fixtures__/flow-package/index.js:10
- 10: var bad1: Object = obj;
+"__tests__/__fixtures__/flow-package/index.js:11
+ 11: var bad1: Object = obj;
                         ^^^ null. This type is incompatible with
- 10: var bad1: Object = obj;
+ 11: var bad1: Object = obj;
                ^^^^^^ object type
 
-__tests__/__fixtures__/flow-package/index.js:10
- 10: var bad1: Object = obj;
+__tests__/__fixtures__/flow-package/index.js:11
+ 11: var bad1: Object = obj;
                         ^^^ undefined. This type is incompatible with
- 10: var bad1: Object = obj;
+ 11: var bad1: Object = obj;
                ^^^^^^ object type
 
 
@@ -23,8 +23,8 @@ Found 2 errors
 exports[`nullthrows with typescript 1`] = `""`;
 
 exports[`nullthrows with typescript 2`] = `
-"__tests__/__fixtures__/typescript-package/index.ts(9,5): error TS2322: Type 'string | null' is not assignable to type 'string'.
+"__tests__/__fixtures__/typescript-package/index.ts(10,5): error TS2322: Type 'string | null' is not assignable to type 'string'.
   Type 'null' is not assignable to type 'string'.
-__tests__/__fixtures__/typescript-package/index.ts(11,5): error TS2322: Type 'string' is not assignable to type 'number'.
+__tests__/__fixtures__/typescript-package/index.ts(12,5): error TS2322: Type 'string' is not assignable to type 'number'.
 "
 `;

--- a/__tests__/nullthrows-test.js
+++ b/__tests__/nullthrows-test.js
@@ -29,4 +29,8 @@ test('it throws', () => {
   expect(() => {
     nullthrows(undefined);
   }).toThrow(new Error('Got unexpected null or undefined'));
+
+  expect(() => {
+    nullthrows(undefined, 'My error message');
+  }).toThrow(new Error('My error message'));
 });

--- a/nullthrows.d.ts
+++ b/nullthrows.d.ts
@@ -2,4 +2,4 @@
  * Throws if value is null or undefined, otherwise returns value.
  */
 
-export default function nullthrows<T>(value?: T | null): T;
+export default function nullthrows<T>(value?: T | null, message?: string): T;

--- a/nullthrows.js
+++ b/nullthrows.js
@@ -2,9 +2,9 @@
 
 Object.defineProperty(exports, '__esModule', {value: true});
 
-exports.default = function nullthrows(x) {
+exports.default = function nullthrows(x, message) {
   if (x != null) {
     return x;
   }
-  throw new Error('Got unexpected null or undefined');
+  throw new Error(message !== undefined ? message : 'Got unexpected null or undefined');
 };

--- a/nullthrows.js.flow
+++ b/nullthrows.js.flow
@@ -1,3 +1,3 @@
 /* @flow */
 
-declare export default function nullthrows<T>(x: ?T): T;
+declare export default function nullthrows<T>(x: ?T, message?: string): T;


### PR DESCRIPTION
E.g. `nullthrows(getConfig(), 'Config not found')`

This helps leverage `nullthrows` for more user-facing errors.