### PR TITLE
Change default error message to specify null or undefined

### DIFF
--- a/__tests__/nullthrows-test.js
+++ b/__tests__/nullthrows-test.js
@@ -24,11 +24,11 @@ test('it does not throw', () => {
 test('it throws', () => {
   expect(() => {
     nullthrows(null);
-  }).toThrow(new Error('Got unexpected null or undefined'));
+  }).toThrow(new Error('Got unexpected null'));
 
   expect(() => {
     nullthrows(undefined);
-  }).toThrow(new Error('Got unexpected null or undefined'));
+  }).toThrow(new Error('Got unexpected undefined'));
 
   expect(() => {
     nullthrows(undefined, 'My error message');

--- a/nullthrows.js
+++ b/nullthrows.js
@@ -6,5 +6,7 @@ exports.default = function nullthrows(x, message) {
   if (x != null) {
     return x;
   }
-  throw new Error(message !== undefined ? message : 'Got unexpected ' + x);
+  var error = new Error(message !== undefined ? message : 'Got unexpected ' + x);
+  error.framesToPop = 1; // Skip nullthrows's own stack frame.
+  throw error;
 };

--- a/nullthrows.js
+++ b/nullthrows.js
@@ -6,5 +6,5 @@ exports.default = function nullthrows(x, message) {
   if (x != null) {
     return x;
   }
-  throw new Error(message !== undefined ? message : 'Got unexpected null or undefined');
+  throw new Error(message !== undefined ? message : 'Got unexpected ' + x);
 };


### PR DESCRIPTION
We can trivially make `nullthrows` provide more details about what it received that was unexpected.