### PR TITLE
Add NonNullable to typescript typedef return type

### DIFF
--- a/__tests__/__fixtures__/typescript-package/index.ts
+++ b/__tests__/__fixtures__/typescript-package/index.ts
@@ -10,3 +10,32 @@ var good2: string = nullthrows(fn(), 'my error message');
 var bad1: string = fn();
 
 var bad2: number = nullthrows(fn());
+
+/**
+ * A simple function that returns a conditional type based on nullability of the input type variable
+ */
+function doSomething<T>(
+  param: T,
+): null extends T ? 'a' | null : 'a' {
+  if (!param) {
+    return null as null extends T ? 'a' | null : 'a';
+  }
+  return 'a' as null extends T ? 'a' | null : 'a';
+}
+
+/**
+ * A wrapper function that removes the possibility of returning null by using `nullthrows`.
+ * It should remove null from both possible return types of the conditional type and typecheck correctly.
+ */
+function nonNullableWrappedDoSomething<T>(param: T): 'a' {
+  return nullthrows(doSomething(param));
+}
+
+/**
+ * A wrapper function that is incorrectly typed as it still could return null based on the conditional type.
+ * This test case is included to ensure nothing about the underlying assumption changes:
+ * that a `nullthrows` is required to get this to typecheck.
+ */
+function incorrectlyTypedWrappedDoSomething<T>(param: T): 'a' {
+  return doSomething(param);
+}

--- a/__tests__/__snapshots__/typechecker-test.js.snap
+++ b/__tests__/__snapshots__/typechecker-test.js.snap
@@ -74,5 +74,8 @@ exports[`nullthrows with typescript 2`] = `
 "__tests__/__fixtures__/typescript-package/index.ts(10,5): error TS2322: Type 'string | null' is not assignable to type 'string'.
   Type 'null' is not assignable to type 'string'.
 __tests__/__fixtures__/typescript-package/index.ts(12,5): error TS2322: Type 'string' is not assignable to type 'number'.
+__tests__/__fixtures__/typescript-package/index.ts(40,3): error TS2322: Type 'null extends T ? \\"a\\" | null : \\"a\\"' is not assignable to type '\\"a\\"'.
+  Type '\\"a\\" | null' is not assignable to type '\\"a\\"'.
+    Type 'null' is not assignable to type '\\"a\\"'.
 "
 `;

--- a/nullthrows.d.ts
+++ b/nullthrows.d.ts
@@ -2,4 +2,4 @@
  * Throws if value is null or undefined, otherwise returns value.
  */
 
-export default function nullthrows<T>(value?: T | null, message?: string): T;
+export default function nullthrows<T>(value?: T | null, message?: string): NonNullable<T>;


### PR DESCRIPTION
# Why

The `NonNullable` utility type (https://www.typescriptlang.org/docs/handbook/utility-types.html#nonnullabletype) excludes `null` and `undefined` from a type. While the previous type signature removed null from primitives and simple nullable/undefined-able types, it doesn't remove null from more complex nullable types like conditional types with a nullable branch.

# How

1. Wrap the return type in `NonNullable` since the returned value is guaranteed not to be null or undefined based on the condition:
```
if (x != null) {
  return x;
}
```
2. Add test showing the use case. Note that without `NonNullable`, `nonNullableWrappedDoSomething` doesn't typecheck.

# Test Plan

1. Temporarily remove `NonNullable` from the returned type.
1. See that the code no longer typechecks.
1. Add `NonNullable`, see it typechecks correctly and matches the test snapshot (the test passes).