### PR TITLE
Make .d.ts work with TS 4.7 in "nodenext"  (ESM) mode

### DIFF
--- a/nullthrows.d.ts
+++ b/nullthrows.d.ts
@@ -2,4 +2,9 @@
  * Throws if value is null or undefined, otherwise returns value.
  */
 
-export default function nullthrows<T>(value?: T | null, message?: string): T;
+ declare function nullthrows<T>(value?: T | null, message?: string): T;
+ declare namespace nullthrows {
+   export { nullthrows as default };
+ }
+ export = nullthrows;
+ 


### PR DESCRIPTION
The upcoming version of TypeScript adds support for ESM by specifying `"module": "nodenext"`. When this is enabled, it interprets `import nullthrows from 'nullthrows'` to mean importing the entire exports object, not just the default export.

This new type declaration matches how nullthrow's JS is implemented: the function is exported both as the CJS exports object and as a property named `default`.

Tested by importing nullthrows (with these changes) in a TS 4.7 project configured to target nodenext. Verified that this fixes type checking. Verified the existing tests in this repo pass.